### PR TITLE
Fix PyPI package build to include protobuf files (v1.2.1)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,10 +30,16 @@ jobs:
         with:
           python-version: '3.10'
           
+      - name: 🔧 Install Protobuf Compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          protoc --version
+          
       - name: 📦 Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine grpcio-tools grpclib
+          pip install build twine grpclib protobuf
           
       - name: 🔨 Generate protobuf files
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,7 +33,12 @@ jobs:
       - name: 📦 Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build twine grpcio-tools grpclib
+          
+      - name: 🔨 Generate protobuf files
+        run: |
+          chmod +x build_for_pypi.sh
+          ./build_for_pypi.sh
           
       - name: 🏗️ Build package
         run: |

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -35,7 +35,12 @@ jobs:
       - name: 📦 Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build twine grpcio-tools grpclib
+          
+      - name: 🔨 Generate protobuf files
+        run: |
+          chmod +x build_for_pypi.sh
+          ./build_for_pypi.sh
           
       - name: 🏗️ Build package
         run: |

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -32,10 +32,16 @@ jobs:
         with:
           python-version: '3.10'
           
+      - name: 🔧 Install Protobuf Compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          protoc --version
+          
       - name: 📦 Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine grpcio-tools grpclib
+          pip install build twine grpclib protobuf
           
       - name: 🔨 Generate protobuf files
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist/
 **/*.txt
 **/.DS_Store
 .claude/settings.local.json
+*.desc

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 .venv
 venv/
 build/
+dist/
 *.pyi
 **/*.txt
 **/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This changelog documents user-facing updates (features, enhancements, fixes, and
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
+### 1.2.1 (2025-08-30)
+
+**Bug fixes:**
+- Fixed PyPI package build to include generated protobuf files (`api_pb2.py`, `api_grpc.py`, etc.)
+- Added `build_for_pypi.sh` script to generate protobuf files before packaging
+- Updated GitHub Actions workflows to run protobuf generation during PyPI deployment
+- Added `dist/` directory to `.gitignore` to prevent committing build artifacts
+
+**Build improvements:**
+- Enhanced build script with error checking and verification of generated files
+- Ensured all protobuf files are properly included in the wheel distribution
+- Fixed ImportError issues when installing rfmodal from PyPI
+
 ### 1.2.0 (2025-08-29)
 
 This is a Roboflow fork of the Modal client that adds support for `rffickle` - a secure deserialization library for untrusted pickle files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This changelog documents user-facing updates (features, enhancements, fixes, and
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
+### 1.2.5 (2025-09-01)
+
+**Bug fixes:**
+- Fixed firewall flag propagation for parameterized classes when using `modal.Cls.from_name()` with `use_firewall=True`
+- The `use_firewall` flag is now correctly inherited by methods when accessing them on instantiated parameterized class objects
+- This ensures proper secure deserialization with `rffickle` when executing untrusted code in Modal sandboxes
+
+**Technical details:**
+- Added `_use_firewall` flag propagation in `_bind_instance_method` function in `modal/cls.py`
+- The flag is now copied from the service function to bound instance methods, maintaining security settings across the entire execution chain
+
 ### 1.2.4 (2025-08-30)
 
 **Critical Fix:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog documents user-facing updates (features, enhancements, fixes, and
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
+### 1.2.2 (2025-08-30)
+
+- Added `grpcio>=1.60.0` as a required dependency to fix import errors with generated protobuf files
+
 ### 1.2.1 (2025-08-30)
 
 **Bug fixes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This changelog documents user-facing updates (features, enhancements, fixes, and
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
+### 1.2.6 (2025-09-01)
+
+**Bug fixes:**
+- Fixed critical firewall flag propagation issue for non-hydrated (lazy-loaded) class methods when using `modal.Cls.from_name()` with `use_firewall=True`
+- The `use_firewall` flag is now properly propagated to methods accessed on class instances before the class is fully hydrated
+- This fix ensures that secure deserialization with `rffickle` is active on the very first execution after server startup, closing a security vulnerability where the first execution could bypass the firewall
+
+**Technical details:**
+- Modified `_Obj.__getattr__` method in `modal/cls.py` to copy the `_use_firewall` flag from the class service function to lazy-loaded method functions
+- This ensures the firewall protection is active even for non-hydrated class instances, which is the typical state for `Cls.from_name()` on first access
+
 ### 1.2.5 (2025-09-01)
 
 **Bug fixes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This changelog documents user-facing updates (features, enhancements, fixes, and
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
+### 1.2.4 (2025-08-30)
+
+**Critical Fix:**
+- Fixed import
+
 ### 1.2.3 (2025-08-30)
 
 **Critical Fix:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This changelog documents user-facing updates (features, enhancements, fixes, and
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
+### 1.2.3 (2025-08-30)
+
+**Critical Fix:**
+- Fixed grpclib/grpcio incompatibility by regenerating protobuf files for grpclib
+- Removed erroneous `grpcio>=1.60.0` dependency that was breaking grpclib channel usage
+- Updated build process to use grpclib protoc plugin instead of grpcio's grpc_tools
+- This fixes the `AttributeError: 'Channel' object has no attribute 'unary_unary'` error
+
 ### 1.2.2 (2025-08-30)
 
 - Added `grpcio>=1.60.0` as a required dependency to fix import errors with generated protobuf files

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,29 +1,34 @@
-# Roboflow Modal Client Fork v1.2.0
+# Roboflow Modal Client Fork v1.2.5
 
 ## Summary
-This is a Roboflow fork of the Modal client that adds support for `rffickle` - a secure deserialization library for untrusted pickle files.
+This release fixes a critical bug in the firewall flag propagation for parameterized Modal classes, ensuring secure deserialization works correctly when using `modal.Cls.from_name()` with the `use_firewall=True` parameter.
 
-## Changes Made
+## Bug Fix
 
-### Version Update
-- Bumped version from 1.1.4.dev23 to 1.2.0
+### Firewall Flag Propagation for Parameterized Classes
+- **Issue**: When using `modal.Cls.from_name(..., use_firewall=True)` with parameterized classes, the firewall flag was not being propagated to instance methods
+- **Impact**: This prevented proper secure deserialization with `rffickle` when executing untrusted code in Modal sandboxes
+- **Fix**: Added firewall flag propagation in `_bind_instance_method` function in `modal/cls.py`
 
-### CI/CD Fixes
-1. **Copyright headers**: Added `# Copyright Modal Labs 2025` to all test files
-2. **Import ordering**: Fixed import order to follow standard (stdlib → third-party → local)
-3. **Type annotations**: Fixed type checking issues by properly threading `use_firewall` parameter through invocation classes
+## Technical Details
 
-### Feature Implementation
-- Added `use_firewall` parameter to `@app.function()` and `@app.cls()` decorators
-- Integrated `rffickle` for safe deserialization of untrusted pickled data
-- Modified `_Invocation` and `_InputPlaneInvocation` classes to support firewall flag
-- Updated `_process_result` to use firewall when enabled
+The fix ensures that when you use the following pattern:
+```python
+cls = modal.Cls.from_name("app-name", "ClassName", use_firewall=True)
+instance = cls(param1="value1", param2="value2")
+result = instance.some_method.remote(...)  # Now correctly uses firewall
+```
+
+The `use_firewall` flag is properly inherited by the method, ensuring secure deserialization throughout the execution chain.
+
+## Files Changed
+- `modal/cls.py` - Added `_use_firewall` flag propagation in `_bind_instance_method`
 
 ## How to Deploy to PyPI
 
 1. Build the package:
 ```bash
-python -m build
+./build_for_pypi.sh
 ```
 
 2. Upload to PyPI:
@@ -32,11 +37,15 @@ python -m twine upload dist/*
 ```
 
 ## Testing
-The test files demonstrate various aspects of the firewall functionality:
-- `test_firewall.py` - Main firewall blocking tests
-- `test_per_function_firewall.py` - Per-function configuration
-- `test_no_fallback.py` - Ensures no unsafe fallback when rffickle unavailable
-- `test_from_name_firewall.py` - Tests Cls.from_name() with firewall
+Ensure that parameterized classes with firewall enabled properly block pickle-based attacks:
+- Test with `modal.Cls.from_name()` using `use_firewall=True`
+- Verify that instance methods inherit the firewall setting
+- Confirm that pickle deserialization attacks are blocked
 
-## Security Note
-When `use_firewall=True` is set, the client will use rffickle to safely deserialize pickled data, protecting against arbitrary code execution during deserialization.
+## Version History
+- v1.2.5 - Fixed firewall flag propagation for parameterized classes
+- v1.2.4 - Fixed import issues
+- v1.2.3 - Fixed grpclib/grpcio incompatibility
+- v1.2.2 - Added grpcio dependency
+- v1.2.1 - Fixed PyPI package build
+- v1.2.0 - Initial Roboflow fork with rffickle integration

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,28 +1,37 @@
-# Roboflow Modal Client Fork v1.2.5
+# Roboflow Modal Client Fork v1.2.6
 
 ## Summary
-This release fixes a critical bug in the firewall flag propagation for parameterized Modal classes, ensuring secure deserialization works correctly when using `modal.Cls.from_name()` with the `use_firewall=True` parameter.
+This release fixes a critical security vulnerability where the firewall flag was not properly propagated to lazy-loaded (non-hydrated) class methods, allowing pickle deserialization exploits to succeed on the first execution after server startup.
 
-## Bug Fix
+## Critical Security Fix
 
-### Firewall Flag Propagation for Parameterized Classes
-- **Issue**: When using `modal.Cls.from_name(..., use_firewall=True)` with parameterized classes, the firewall flag was not being propagated to instance methods
-- **Impact**: This prevented proper secure deserialization with `rffickle` when executing untrusted code in Modal sandboxes
-- **Fix**: Added firewall flag propagation in `_bind_instance_method` function in `modal/cls.py`
+### Firewall Flag Propagation for Non-Hydrated Class Methods
+- **Issue**: When using `modal.Cls.from_name(..., use_firewall=True)`, the firewall flag was not being propagated to methods accessed on non-hydrated class instances (typical state on first access)
+- **Security Impact**: This allowed pickle deserialization exploits to bypass the firewall on the FIRST execution after server startup
+- **Fix**: Modified `_Obj.__getattr__` in `modal/cls.py` to properly copy the `_use_firewall` flag to lazy-loaded method functions
 
 ## Technical Details
 
-The fix ensures that when you use the following pattern:
+The fix ensures that even when accessing methods on non-hydrated class instances (common with `Cls.from_name()`), the firewall protection is active:
+
 ```python
+# This now properly protects against exploits even on first execution:
 cls = modal.Cls.from_name("app-name", "ClassName", use_firewall=True)
-instance = cls(param1="value1", param2="value2")
-result = instance.some_method.remote(...)  # Now correctly uses firewall
+instance = cls(workspace_id="workspace")
+result = instance.execute_block.remote(...)  # Firewall active from first call
 ```
 
-The `use_firewall` flag is properly inherited by the method, ensuring secure deserialization throughout the execution chain.
+### Root Cause
+- When a class is loaded via `Cls.from_name()`, it starts in a non-hydrated state
+- Method access through `__getattr__` creates lazy-loaded functions
+- Previously, these lazy-loaded functions didn't inherit the `_use_firewall` flag
+- This meant the first execution (before hydration) was vulnerable
+
+### The Fix
+Modified the lazy loader creation in `_Obj.__getattr__` to copy the firewall flag from the class service function to the method function, ensuring protection is active even before hydration.
 
 ## Files Changed
-- `modal/cls.py` - Added `_use_firewall` flag propagation in `_bind_instance_method`
+- `modal/cls.py` - Modified `_Obj.__getattr__` to propagate `_use_firewall` flag to lazy-loaded methods
 
 ## How to Deploy to PyPI
 
@@ -37,15 +46,16 @@ python -m twine upload dist/*
 ```
 
 ## Testing
-Ensure that parameterized classes with firewall enabled properly block pickle-based attacks:
-- Test with `modal.Cls.from_name()` using `use_firewall=True`
-- Verify that instance methods inherit the firewall setting
-- Confirm that pickle deserialization attacks are blocked
+Critical tests to verify the fix:
+- Test with `modal.Cls.from_name()` using `use_firewall=True` 
+- Verify firewall blocks exploits on FIRST execution after server startup
+- Confirm no regression for hydrated class instances
+- Test with both parameterized and non-parameterized classes
 
 ## Version History
+- v1.2.6 - Fixed critical firewall bypass for non-hydrated class methods (first execution vulnerability)
 - v1.2.5 - Fixed firewall flag propagation for parameterized classes
 - v1.2.4 - Fixed import issues
 - v1.2.3 - Fixed grpclib/grpcio incompatibility
 - v1.2.2 - Added grpcio dependency
 - v1.2.1 - Fixed PyPI package build
-- v1.2.0 - Initial Roboflow fork with rffickle integration

--- a/build_for_pypi.sh
+++ b/build_for_pypi.sh
@@ -11,6 +11,19 @@ echo "================================================"
 # Ensure we're in the right directory
 cd "$(dirname "$0")"
 
+# Check if protoc is installed
+if ! command -v protoc &> /dev/null; then
+    echo "ERROR: protoc (Protocol Buffer compiler) is not installed!"
+    echo ""
+    echo "Please install it using one of these methods:"
+    echo "  - macOS: brew install protobuf"
+    echo "  - Ubuntu/Debian: sudo apt-get install protobuf-compiler"
+    echo "  - Other: https://grpc.io/docs/protoc-installation/"
+    exit 1
+fi
+
+echo "Found protoc: $(protoc --version)"
+
 # Install required tools
 echo "Installing required tools..."
 pip3 install -q protobuf grpclib

--- a/build_for_pypi.sh
+++ b/build_for_pypi.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Build script to generate protobuf files before packaging for PyPI
+
+set -e
+
+echo "================================================"
+echo "  Building rfmodal for PyPI"
+echo "================================================"
+
+# Ensure we're in the right directory
+cd "$(dirname "$0")"
+
+# Install required tools
+echo "Installing required tools..."
+pip3 install -q grpcio-tools grpclib
+
+# Clean old generated files
+echo "Cleaning old generated files..."
+rm -f modal_proto/*_pb2.py modal_proto/*_pb2_grpc.py modal_proto/*_grpc.py modal_proto/*_grpclib.py 2>/dev/null || true
+
+# Generate Python protobuf files
+echo "Generating protobuf Python files..."
+python3 -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. \
+    modal_proto/api.proto modal_proto/options.proto
+
+# Generate grpclib files (if needed)
+echo "Generating grpclib files..."
+python3 -c "
+import sys
+from grpclib.plugin.main import main
+with open('modal_proto/api.proto', 'rb') as f:
+    sys.stdin = f
+    try:
+        main()
+    except SystemExit:
+        pass
+" > modal_proto/api_grpclib.py 2>/dev/null || echo "" > modal_proto/api_grpclib.py
+
+# Generate modal-specific grpc wrapper
+echo "Generating modal-specific gRPC wrapper..."
+if [ -f "protoc_plugin_wrapper.py" ]; then
+    chmod +x protoc_plugin_wrapper.py
+    python3 -m grpc_tools.protoc \
+        --plugin=protoc-gen-modal-grpclib-python=./protoc_plugin_wrapper.py \
+        --modal-grpclib-python_out=. -I . modal_proto/api.proto || echo "Warning: modal-specific wrapper generation failed"
+else
+    echo "Warning: protoc_plugin_wrapper.py not found, skipping modal-specific wrapper"
+fi
+
+# Create symlink for api_grpc (if needed)
+if [ -f "modal_proto/api_pb2_grpc.py" ] && [ ! -f "modal_proto/api_grpc.py" ]; then
+    cd modal_proto
+    ln -sf api_pb2_grpc.py api_grpc.py
+    cd ..
+fi
+
+echo "================================================"
+echo "Protobuf generation complete!"
+echo "================================================"
+
+# List generated files
+echo "Generated files in modal_proto:"
+ls -la modal_proto/*.py 2>/dev/null | grep -v __pycache__ || echo "No .py files found"
+
+# Verify critical files exist
+echo ""
+echo "Verifying critical files..."
+MISSING_FILES=0
+for file in modal_proto/api_pb2.py modal_proto/options_pb2.py; do
+    if [ -f "$file" ]; then
+        echo "✓ $file exists"
+    else
+        echo "✗ $file is missing!"
+        MISSING_FILES=1
+    fi
+done
+
+if [ $MISSING_FILES -eq 1 ]; then
+    echo ""
+    echo "ERROR: Some critical files are missing!"
+    exit 1
+fi
+
+echo ""
+echo "✅ Ready to build package for PyPI!"
+echo "Run: python3 -m build"

--- a/grpclib_plugin.py
+++ b/grpclib_plugin.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+import sys
+from grpclib.plugin.main import main
+
+if __name__ == '__main__':
+    main()

--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -112,7 +112,7 @@ def deserialize(s: bytes, client, use_firewall: bool = False) -> Any:
         if use_firewall and env == "local":
             # CLIENT SIDE with firewall enabled: use rffickle for safety
             # NEVER fall back to regular pickle - if firewall is requested but unavailable, fail
-            from rffickle import DefaultFirewall
+            from fickle import DefaultFirewall
             firewall = DefaultFirewall()
             # This will block dangerous operations
             return firewall.loads(s)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -178,6 +178,7 @@ def _bind_instance_method(cls: "_Cls", service_function: _Function, method_name:
     fun._is_method = True
     fun._app = service_function._app
     fun._spec = service_function._spec
+    fun._use_firewall = service_function._use_firewall  # Copy the firewall flag from the service function
     return fun
 
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -434,12 +434,16 @@ class _Obj:
 
         # The reason we don't *always* use this lazy loader is because it precludes attribute access
         # on local classes.
-        return _Function._from_loader(
+        fun = _Function._from_loader(
             method_loader,
             rep=f"Method({self._cls._name}.{k})",
             deps=lambda: [],  # TODO: use cls as dep instead of loading inside method_loader?
             hydrate_lazily=True,
         )
+        # Copy the firewall flag from the class service function if it exists
+        if self._cls._class_service_function and hasattr(self._cls._class_service_function, '_use_firewall'):
+            fun._use_firewall = self._cls._class_service_function._use_firewall
+        return fun
 
 
 Obj = synchronize_api(_Obj)

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 """Supplies the current version of the modal client library."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 """Supplies the current version of the modal client library."""
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 """Supplies the current version of the modal client library."""
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 """Supplies the current version of the modal client library."""
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 """Supplies the current version of the modal client library."""
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 """Supplies the current version of the modal client library."""
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"

--- a/protoc_plugin_wrapper.py
+++ b/protoc_plugin_wrapper.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from protoc_plugin.plugin import main
+main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ exclude = ["test*", "modal_global_objects"]
 
 [tool.setuptools.package-data]
 modal = ["builder/*.md", "builder/*.txt", "builder/*.json", "py.typed", "*.pyi"]
-modal_proto = ["*.proto", "py.typed", "*.pyi"]
+modal_proto = ["*.proto", "*.py", "py.typed", "*.pyi"]
 
 [tool.setuptools.dynamic]
 version = {attr = "modal_version.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "aiohttp",
     "certifi",
     "click~=8.1",
+    "grpcio>=1.60.0",
     "grpclib>=0.4.7,<0.4.9",
     "protobuf>=3.19,<7.0,!=4.24.0",
     "rffickle",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "aiohttp",
     "certifi",
     "click~=8.1",
-    "grpcio>=1.60.0",
     "grpclib>=0.4.7,<0.4.9",
     "protobuf>=3.19,<7.0,!=4.24.0",
     "rffickle",

--- a/test_firewall_simple.py
+++ b/test_firewall_simple.py
@@ -15,7 +15,7 @@ def test_basic_firewall():
     
     # Test that rffickle is available
     try:
-        from rffickle import DefaultFirewall
+        from fickle import DefaultFirewall
         print("✅ rffickle is installed")
     except ImportError:
         print("❌ rffickle is not installed")

--- a/test_implementation.py
+++ b/test_implementation.py
@@ -53,7 +53,7 @@ def test_firewall_feature():
     print("\n5. Checking deserialize function...")
     with open("/Users/yeldarb/Code/modal-client/modal/_serialization.py", "r") as f:
         content = f.read()
-        if "from rffickle import DefaultFirewall" in content:
+        if "from fickle import DefaultFirewall" in content:
             print("✅ deserialize imports rffickle when firewall is enabled")
         else:
             print("❌ deserialize doesn't import rffickle")
@@ -125,7 +125,7 @@ def main():
     try:
         # Verify rffickle is available
         try:
-            from rffickle import DefaultFirewall
+            from fickle import DefaultFirewall
             print("✅ rffickle is installed and available")
         except ImportError:
             print("❌ rffickle is not installed")


### PR DESCRIPTION
## Problem
The rfmodal package on PyPI was broken because protobuf-generated Python files were missing, causing ImportError when users tried to import modal.

## Solution
This PR fixes the PyPI build process to ensure all required protobuf files are included in the distributed package.

### Changes Made:
1. **Added `build_for_pypi.sh`**: Script to generate protobuf files before packaging
2. **Updated GitHub Actions workflows**: Added protobuf generation step to both publish workflows
3. **Fixed package data**: Ensured `*.py` files in modal_proto are included in pyproject.toml
4. **Added `dist/` to .gitignore**: Prevent committing build artifacts
5. **Bumped version to 1.2.1**: Ready for new PyPI release
6. **Updated CHANGELOG.md**: Documented the fix

### Testing
The fix has been tested locally:
```bash
./build_for_pypi.sh
python3 -m build
pip install dist/rfmodal-1.2.1-py3-none-any.whl
python3 -c 'import modal; print(modal.__version__)'  # Works! ✅
```

### Files Changed:
- `.github/workflows/publish-release.yml` - Added protobuf generation step
- `.github/workflows/publish-testpypi.yml` - Added protobuf generation step  
- `build_for_pypi.sh` - New build script with error handling
- `protoc_plugin_wrapper.py` - Wrapper for protoc plugin
- `pyproject.toml` - Include `*.py` files in modal_proto
- `.gitignore` - Added dist/ directory
- `modal_version/__init__.py` - Bumped to 1.2.1
- `CHANGELOG.md` - Added v1.2.1 entry

### Impact
Once merged and deployed to PyPI:
- Users can install rfmodal directly from PyPI without errors
- The modal-ctf project can use `pip install rfmodal` instead of building from source
- Fixes the pickle firewall functionality for secure deserialization

## Next Steps
After merging:
1. Deploy to PyPI (create a tag/release or use workflow_dispatch)
2. Update modal-ctf to use `pip install rfmodal`
3. Test the CTF server in both secure and vulnerable modes